### PR TITLE
Hook to "woocommerce_remove_cart_item" event

### DIFF
--- a/includes/integration.php
+++ b/includes/integration.php
@@ -279,6 +279,7 @@ class Metrilo_Woo_Analytics_Integration extends WC_Integration {
 		// background events tracking
 		add_action('woocommerce_add_to_cart', array($this, 'add_to_cart'), 10, 6);
 		add_action('woocommerce_before_cart_item_quantity_zero', array($this, 'remove_from_cart'), 10);
+    add_action('woocommerce_remove_cart_item', array($this, 'remove_from_cart'), 10);
 		add_filter('woocommerce_applied_coupon', array($this, 'applied_coupon'), 10);
 
 		// hook on new order placed


### PR DESCRIPTION
When an item is removed from the "X" icon on cart page, we don't send `remove_from_cart` event.