### PR TITLE
PLG-46: save applied_coupon event in cookie

### DIFF
--- a/includes/integration.php
+++ b/includes/integration.php
@@ -787,7 +787,7 @@ class Metrilo_Woo_Analytics_Integration extends WC_Integration {
     }
 
     public function applied_coupon($coupon_code){
-        $this->put_event_in_queue('track', 'applied_coupon', $coupon_code);
+        $this->put_event_in_cookie_queue('track', 'applied_coupon', $coupon_code);
     }
 
     public function new_order_event($order_id){


### PR DESCRIPTION
Saving applied_coupon event in cookie will ensure the information about the coupon will be send to Metrilo.