### PR TITLE
KYP-902: Wordpress Metrilo plugin sends first name as "last_name" parameter

### DIFF
--- a/includes/integration.php
+++ b/includes/integration.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'Metrilo_Woo_Analytics_Integration' ) ) :
 
 class Metrilo_Woo_Analytics_Integration extends WC_Integration {
     
-    private $integration_version = '1.7.13';
+    private $integration_version = '1.7.14';
     private $events_queue = array();
     private $single_item_tracked = false;
     private $has_events_in_cookie = false;
@@ -417,7 +417,7 @@ class Metrilo_Woo_Analytics_Integration extends WC_Integration {
         $email     = get_post_meta($this->object_property($order, 'order', 'id'), '_billing_email', true);
         $phone     = get_post_meta($this->object_property($order, 'order', 'id'), '_billing_phone', true);
         $firstName = get_post_meta($this->object_property($order, 'order', 'id'), '_billing_first_name', true);
-        $lastName  = get_post_meta($this->object_property($order, 'order', 'id'), '_billing_first_name', true);
+        $lastName  = get_post_meta($this->object_property($order, 'order', 'id'), '_billing_last_name', true);
     
         $identity_data = array(
             'email'         => $email ? $email : $phone . '@phone_email',

--- a/metrilo-woocommerce-integration.php
+++ b/metrilo-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Metrilo for WooCommerce
  * Plugin URI: https://www.metrilo.com/woocommerce-analytics
  * Description: One-click WooCommerce integration with Metrilo eCommerce Analytics
- * Version: 1.7.13
+ * Version: 1.7.14
  * Author: Metrilo
  * Author URI: https://www.metrilo.com/?ref=wpplugin
  * License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: MurryIvanoff
 Tags: woocommerce, analytics, reporting, tracking, woo, ecommerce, funnels, metrics, kissmetrics, mixpanel, crm, history, products, items, rjmetrics, analytics dashboard, google analytics, products, retention, coupons, customers, big data, customer relationship management, subscriptions, woocommerce subscriptions, churn, customer analytics, insights, ltv, email marketing, email, triggered emails, cohorts, sales analytics, customer intelligence, email marketing, automation, cart abandonment, cart recovery
 Requires at least: 2.9.2
 Tested up to: 5.2.3
-Stable Tag: 1.7.13
+Stable Tag: 1.7.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -92,6 +92,9 @@ Absolutely! We offer a 14-day free trial on every plan. No obligation. No credit
 5. Easily build and send personalized responsive email campaigns
 
 == Changelog ==
+
+= 1.7.14 =
+* Fixed: Last name parameter taking values for First name when syncing data with Metrilo.
 
 = 1.7.13 =
 * New: Additional functionality to handle phone orders.


### PR DESCRIPTION
Fixed wrong values for last name before order sync