### PR TITLE
KYP-986: Fixed error logging for deprecated function

### DIFF
--- a/includes/integration.php
+++ b/includes/integration.php
@@ -1024,9 +1024,15 @@ class Metrilo_Woo_Analytics_Integration extends WC_Integration {
                 $purchase_params[$k] = $val;
             }
         }
-
+    
         // attach coupons data
-        $coupons_applied = $order->get_used_coupons();
+        global $woocommerce;
+        if ( version_compare( $woocommerce->version, '3.7', ">" ) ) {
+            $coupons_applied = $order->get_coupon_codes();
+        } else {
+            $coupons_applied = $order->get_used_coupons();
+        }
+        
         if(count($coupons_applied) > 0){
             $purchase_params['coupons'] = $coupons_applied;
         }


### PR DESCRIPTION
Woocommerce versions lower or equal to 3.7 support get_used_coupons(), newer versions should use get_coupon_codes()