### PR TITLE
KYP-1375: Release 1.7.18

### DIFF
--- a/includes/integration.php
+++ b/includes/integration.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'Metrilo_Woo_Analytics_Integration' ) ) :
 
 class Metrilo_Woo_Analytics_Integration extends WC_Integration {
     
-    private $integration_version = '1.7.17';
+    private $integration_version = '1.7.18';
     private $events_queue = array();
     private $single_item_tracked = false;
     private $has_events_in_cookie = false;

--- a/metrilo-woocommerce-integration.php
+++ b/metrilo-woocommerce-integration.php
@@ -3,7 +3,7 @@
  * Plugin Name: Metrilo for WooCommerce
  * Plugin URI: https://www.metrilo.com/woocommerce-analytics
  * Description: One-click WooCommerce integration with Metrilo eCommerce Analytics
- * Version: 1.7.17
+ * Version: 1.7.18
  * Author: Metrilo
  * Author URI: https://www.metrilo.com/?ref=wpplugin
  * License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: MurryIvanoff
 Tags: woocommerce, analytics, reporting, tracking, woo, ecommerce, funnels, metrics, kissmetrics, mixpanel, crm, history, products, items, rjmetrics, analytics dashboard, google analytics, products, retention, coupons, customers, big data, customer relationship management, subscriptions, woocommerce subscriptions, churn, customer analytics, insights, ltv, email marketing, email, triggered emails, cohorts, sales analytics, customer intelligence, email marketing, automation, cart abandonment, cart recovery
 Requires at least: 2.9.2
-Tested up to: 5.4.2
-Stable Tag: 1.7.17
+Tested up to: 5.5.1
+Stable Tag: 1.7.18
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -92,6 +92,9 @@ Absolutely! We offer a 14-day free trial on every plan. No obligation. No credit
 5. Easily build and send personalized responsive email campaigns
 
 == Changelog ==
+
+= 1.7.18 =
+* Compatibility update: Tested with Woocommerce versions up to 4.5.1
 
 = 1.7.17 =
 * Fixed: Deprecated get_product method and woocommerce_before_cart_item_quantity_zero action hook usage in woocommerce versions higher than 3.7.

--- a/readme.txt
+++ b/readme.txt
@@ -94,7 +94,7 @@ Absolutely! We offer a 14-day free trial on every plan. No obligation. No credit
 == Changelog ==
 
 = 1.7.18 =
-* Compatibility update: Tested with Woocommerce versions up to 4.5.1
+* Compatibility update: Tested with Woocommerce versions up to 4.5.1 and Wordpress versions up to 5.5.1
 
 = 1.7.17 =
 * Fixed: Deprecated get_product method and woocommerce_before_cart_item_quantity_zero action hook usage in woocommerce versions higher than 3.7.


### PR DESCRIPTION
Version bump for compatibility of the module using Woocommerce versions up to 4.5.1 and Wordpress versions up to 5.5.1